### PR TITLE
📝Lógica de passar perfil e registro de interações #T035

### DIFF
--- a/src/controllers/interactionController.js
+++ b/src/controllers/interactionController.js
@@ -63,4 +63,33 @@ const curtirPerfil = async (req, res) => {
   }
 };
 
-module.exports = { curtirPerfil };
+const passarPerfil = async (req, res) => {
+  const from_user_id = req.user.id;
+  const to_user_id = req.params.usuarioId;
+
+  try {
+    // 1. Validar se não está passando em si mesmo
+    if (from_user_id === to_user_id) {
+      return res.status(400).json({ message: "Você não pode passar a si mesmo." });
+    }
+
+    // 2. Registrar a interação do tipo 'pass'
+    await Interaction.create({
+      from_user_id,
+      to_user_id,
+      type: 'pass'
+    });
+
+    return res.status(201).json({ 
+      message: "Interação registrada (pass)!", 
+      match: false 
+    });
+
+  } catch (error) {
+    console.error("Erro na T035:", error);
+    return res.status(500).json({ error: "Erro ao processar 'passar'." });
+  }
+};
+
+// Não esqueça de exportar a nova função no final do arquivo:
+module.exports = { curtirPerfil, passarPerfil };

--- a/src/controllers/interactionController.js
+++ b/src/controllers/interactionController.js
@@ -1,0 +1,66 @@
+const { Interaction, Match } = require('../models');
+
+const curtirPerfil = async (req, res) => {
+  const from_user_id = req.user.id; // ID de quem está logado (via token)
+  const to_user_id = req.params.usuarioId; // ID de quem está sendo curtido
+
+  try {
+    // 1. Validar se não está curtindo a si mesmo
+    if (from_user_id === to_user_id) {
+      return res.status(400).json({ message: "Você não pode curtir a si mesmo." });
+    }
+
+    // 2. Validar se já não curtiu antes
+    const jaCurtiu = await Interaction.findOne({
+      where: { from_user_id, to_user_id, type: 'like' }
+    });
+
+    if (jaCurtiu) {
+      return res.status(400).json({ message: "Você já curtiu este perfil." });
+    }
+
+    // 3. Registrar a interação na tabela Interactions
+    await Interaction.create({
+      from_user_id,
+      to_user_id,
+      type: 'like'
+    });
+
+    // 4. ENGINE DE MATCH: Verificar se o outro usuário já curtiu este
+    const matchReverso = await Interaction.findOne({
+      where: {
+        from_user_id: to_user_id,
+        to_user_id: from_user_id,
+        type: 'like'
+      }
+    });
+
+    if (matchReverso) {
+      // Registrar na tabela de Matches
+      // Usamos uma lógica simples de ID menor primeiro para evitar duplicidade na lógica
+      const [user1, user2] = from_user_id < to_user_id 
+        ? [from_user_id, to_user_id] 
+        : [to_user_id, from_user_id];
+
+      await Match.findOrCreate({
+        where: { user1_id: user1, user2_id: user2 }
+      });
+
+      return res.status(201).json({ 
+        message: "Interação registrada!", 
+        match: true 
+      });
+    }
+
+    return res.status(201).json({ 
+      message: "Interação registrada!", 
+      match: false 
+    });
+
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: "Erro ao processar curtida." });
+  }
+};
+
+module.exports = { curtirPerfil };

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,7 @@
 const Sequelize = require('sequelize');
 const config = require('../config/database');
 
+
 // Pegamos as configs de dentro da chave 'development' que criamos no database.js
 const dbConfig = config.development; 
 
@@ -15,6 +16,10 @@ const db = {};
 
 // Importa o modelo de usuário que criamos na T014
 db.User = require('./user')(sequelize); 
+//mudei so isso aqui
+db.Interaction = require('./interaction')(sequelize, Sequelize);
+db.Match = require('./match')(sequelize, Sequelize);
+
 
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;

--- a/src/routes/interactionRoutes.js
+++ b/src/routes/interactionRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
 const interactionController = require('../controllers/interactionController');
-const authMiddleware = require('../middlewares/auth');
+const authMiddleware = require('../middlewares/auth'); //VerifyToken Middleware
 
 // Rota para curtir um perfil
 router.post('/curtir/:usuarioId', authMiddleware, interactionController.curtirPerfil);
+router.post('/passar/:usuarioId', authMiddleware, interactionController.passarPerfil);
 
 module.exports = router;

--- a/src/routes/interactionRoutes.js
+++ b/src/routes/interactionRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const interactionController = require('../controllers/interactionController');
+const authMiddleware = require('../middlewares/auth');
+
+// Rota para curtir um perfil
+router.post('/curtir/:usuarioId', authMiddleware, interactionController.curtirPerfil);
+
+module.exports = router;

--- a/src/server.js
+++ b/src/server.js
@@ -37,6 +37,12 @@ db.sequelize.authenticate()
   .then(() => {
     console.log('✅ Conexão com o Banco: OK');
     console.log('📂 Estrutura de Pastas: OK');
+    
+    // Adicionar esta linha:
+    return db.sequelize.sync({});
+  })
+  .then(() => {
+    console.log('✅ Tabelas sincronizadas: OK');
     app.listen(PORT, () => {
       console.log(`🚀 Openest API segura rodando em http://localhost:${PORT}`);
     });

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ const rateLimit = require('express-rate-limit'); // Importa o rate limiter
 const db = require('./models'); // Importa a configuração do Sequelize
 const userRoutes = require('./routes/userRoutes'); // Importando sua organização
 const healthRoutes = require('./routes/healthRoutes'); // Importando sua organização
+const interactionRoutes = require('./routes/interactionRoutes'); // Importando a nova rota de interações
 
 
 
@@ -26,7 +27,8 @@ app.use(limiter);
 // ROTAS
 // Definindo o prefixo das rotas (padrão de API)
 app.use('/api/users', userRoutes);
-app.use('/health', healthRoutes); // Rota direta para monitoramento
+app.use('/health', healthRoutes); 
+app.use('/api', interactionRoutes);// Rota direta para monitoramento
 
 const PORT = 3000;
 


### PR DESCRIPTION
Descrição:
Implementação do endpoint de desinteresse ("Passar") conforme os requisitos da Task T035. Esta funcionalidade permite que o usuário decline perfis sem gerar a detecção de match, mantendo o histórico de interações para evitar repetições no feed.

O que foi feito:

Endpoint: Criada a rota POST /api/passar/:usuarioId.

Validações: Adicionada regra de negócio que impede o usuário de passar em si mesmo (Retorno 400).

Persistência: Registro automático na tabela interactions com o tipo pass.

Segurança: Proteção da rota via middleware de autenticação (JWT).

Banco de Dados: Validação do mapeamento de UUIDs entre o Sequelize e o PostgreSQL.

Critérios de Aceite:

[x] Registro salvo com sucesso no banco de dados.

[x] Resposta 201 Created retornada via Postman.

[x] Middleware capturando corretamente o from_user_id.

<img width="1022" height="669" alt="image" src="https://github.com/user-attachments/assets/3341687a-362f-4187-a5cc-3c4ed3a818b2" />
